### PR TITLE
Feat/my page wide

### DIFF
--- a/src/components/MyPage/AquariumFishTable.tsx
+++ b/src/components/MyPage/AquariumFishTable.tsx
@@ -37,11 +37,11 @@ export default function AquariumFishTable() {
       >
         {/* 헤더 행 */}
         <div className="grid grid-cols-[100px_120px_1fr_180px_160px] items-center gap-4 pb-4">
-          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">SELECT</h4>
-          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">FISH</h4>
-          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">MATURITY</h4>
-          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">REPO</h4>
-          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">
+          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">SELECT</h4>
+          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">FISH</h4>
+          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">MATURITY</h4>
+          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">REPO</h4>
+          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">
             CONTRIBUTION
           </h4>
         </div>
@@ -77,10 +77,10 @@ export default function AquariumFishTable() {
               </div>
 
               {/* MATURITY */}
-              <div className="font-vt text-center text-lg text-white">{r.maturity}</div>
+              <div className="font-vt text-center text-xl text-white">{r.maturity}</div>
 
               {/* REPO 링크 느낌 */}
-              <div className="font-vt text-center text-lg text-white/90">
+              <div className="font-vt text-center text-xl text-white/90">
                 <button
                   className="underline decoration-white/60 underline-offset-2 transition-colors hover:text-white hover:decoration-white"
                   onClick={() => console.log("go repo:", r.repo)}
@@ -90,7 +90,7 @@ export default function AquariumFishTable() {
               </div>
 
               {/* CONTRIBUTION */}
-              <div className="font-vt text-center text-lg text-white">{r.contribution} commits</div>
+              <div className="font-vt text-center text-xl text-white">{r.contribution} commits</div>
             </div>
           ))}
         </div>

--- a/src/components/MyPage/AquariumFishTable.tsx
+++ b/src/components/MyPage/AquariumFishTable.tsx
@@ -25,10 +25,10 @@ export default function AquariumFishTable() {
   };
 
   return (
-    <section className="w-[1500px]">
+    <section className="w-full max-w-[1000px]">
       {/* 서리(유리) 카드 */}
       <div
-        className="rounded-2xl p-8 shadow-lg ring-1 ring-white/40"
+        className="rounded-2xl p-6 shadow-lg ring-1 ring-white/40"
         style={{
           background:
             "linear-gradient(180deg, rgba(255,255,255,0.45) 0%, rgba(255,255,255,0.25) 100%)",
@@ -36,34 +36,34 @@ export default function AquariumFishTable() {
         }}
       >
         {/* 헤더 행 */}
-        <div className="grid grid-cols-[220px_220px_1fr_270px_250px] items-center pb-8">
-          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">SELECT</h4>
-          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">FISH</h4>
-          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">MATURITY</h4>
-          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">REPO</h4>
-          <h4 className="font-vt text-center text-2xl tracking-wider text-[#5A2B55]">
+        <div className="grid grid-cols-[100px_120px_1fr_180px_160px] items-center gap-4 pb-4">
+          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">SELECT</h4>
+          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">FISH</h4>
+          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">MATURITY</h4>
+          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">REPO</h4>
+          <h4 className="font-vt text-center text-xl tracking-wider text-[#5A2B55]">
             CONTRIBUTION
           </h4>
         </div>
 
         {/* 목록 */}
-        <div className="space-y-8">
+        <div className="space-y-4">
           {rows.map((r) => (
             <div
               key={r.id}
-              className="grid grid-cols-[220px_220px_1fr_270px_250px] items-center py-1"
+              className="grid grid-cols-[100px_120px_1fr_180px_160px] items-center gap-4 py-2"
             >
               {/* SELECT 토글 버튼 */}
               <div className="flex justify-center">
                 <button
                   onClick={() => toggleFishSelection(r.id)}
-                  className={`relative h-8 w-16 rounded-full transition-colors duration-200 ${
+                  className={`relative h-6 w-12 rounded-full transition-colors duration-200 ${
                     selectedFish.has(r.id) ? "bg-[#5A2B55]" : "bg-gray-400"
                   }`}
                 >
                   <div
-                    className={`absolute top-1 h-6 w-6 rounded-full bg-white shadow-md transition-transform duration-200 ${
-                      selectedFish.has(r.id) ? "translate-x-9" : "translate-x-1"
+                    className={`absolute top-0.5 h-5 w-5 rounded-full bg-white shadow-md transition-transform duration-200 ${
+                      selectedFish.has(r.id) ? "translate-x-6" : "translate-x-0.5"
                     }`}
                   />
                 </button>
@@ -71,18 +71,18 @@ export default function AquariumFishTable() {
 
               {/* FISH 썸네일 */}
               <div className="justify-self-center">
-                <div className="flex h-30 w-45 items-center justify-center rounded-2xl bg-white/25 shadow-inner transition-transform duration-300 hover:scale-110">
+                <div className="flex h-20 w-28 items-center justify-center rounded-xl bg-white/25 shadow-inner transition-transform duration-300 hover:scale-110">
                   <FishIcon maturity={r.maturity} />
                 </div>
               </div>
 
               {/* MATURITY */}
-              <div className="font-vt text-center text-2xl text-white">{r.maturity}</div>
+              <div className="font-vt text-center text-lg text-white">{r.maturity}</div>
 
               {/* REPO 링크 느낌 */}
-              <div className="font-vt text-center text-2xl text-white/90">
+              <div className="font-vt text-center text-lg text-white/90">
                 <button
-                  className="underline decoration-white/60 underline-offset-4 transition-colors hover:text-white hover:decoration-white"
+                  className="underline decoration-white/60 underline-offset-2 transition-colors hover:text-white hover:decoration-white"
                   onClick={() => console.log("go repo:", r.repo)}
                 >
                   {r.repo}
@@ -90,9 +90,7 @@ export default function AquariumFishTable() {
               </div>
 
               {/* CONTRIBUTION */}
-              <div className="font-vt text-center text-2xl text-white">
-                {r.contribution} commits
-              </div>
+              <div className="font-vt text-center text-lg text-white">{r.contribution} commits</div>
             </div>
           ))}
         </div>

--- a/src/components/MyPage/AquariumSection.tsx
+++ b/src/components/MyPage/AquariumSection.tsx
@@ -69,9 +69,9 @@ export default function AquariumSection() {
   };
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex w-full flex-col px-20">
       {/* 상단 공용 툴바: 버튼들 y좌표 통일하기 위해 만들었음 === */}
-      <div className="mt-5 mb-3 grid grid-cols-[750px_minmax(420px,1fr)] items-center gap-6">
+      <div className="mt-5 mb-3 grid grid-cols-[700px_minmax(420px,1fr)] items-center gap-6">
         {/* 좌: EXPORT */}
         <div className="justify-self-end">
           <button
@@ -122,10 +122,10 @@ export default function AquariumSection() {
       </div>
 
       {/* 본문: 캔버스 / 그리드 === */}
-      <div className="grid grid-cols-[750px_minmax(420px,1fr)] items-start gap-6">
+      <div className="grid grid-cols-[700px_minmax(420px,1fr)] items-start gap-6">
         {/* 좌측: AquariumCanvas */}
         <div className="justify-self-start">
-          <AquariumCanvas width={750} height={440} bgSrc={appliedBgSrc} itemSrc={appliedItemSrc} />
+          <AquariumCanvas width={700} height={440} bgSrc={appliedBgSrc} itemSrc={appliedItemSrc} />
           <p className="font-vt mt-3 text-2xl text-white">Repo contributions: {totalContrib}</p>
         </div>
 

--- a/src/components/MyPage/AquariumSection.tsx
+++ b/src/components/MyPage/AquariumSection.tsx
@@ -72,11 +72,11 @@ export default function AquariumSection() {
     <div className="flex w-full flex-col px-20">
       {/* 상단 공용 툴바: 버튼들 y좌표 통일하기 위해 만들었음 === */}
       <div className="relative mt-5 mb-3">
-        {/* 좌: EXPORT */}
+        {/* 좌: EXPORT 버튼 - 왼쪽 캔버스 영역 오른쪽 끝 */}
         <div className="flex justify-end" style={{ width: "700px" }}>
           <button
             onClick={() => console.log("EXPORT clicked")}
-            className="font-vt ml-4 rounded-full bg-[#3F3F3F]/80 px-8 py-1 text-2xl text-[#D7B9B9] shadow transition-colors hover:bg-[#CA9B9B]/20 focus:ring-2 focus:ring-[#CA9B9B] focus:outline-none"
+            className="font-vt rounded-full bg-[#3F3F3F]/80 px-8 py-1 text-2xl text-[#D7B9B9] shadow transition-colors hover:bg-[#CA9B9B]/20 focus:ring-2 focus:ring-[#CA9B9B] focus:outline-none"
           >
             EXPORT
           </button>

--- a/src/components/MyPage/AquariumSection.tsx
+++ b/src/components/MyPage/AquariumSection.tsx
@@ -71,9 +71,9 @@ export default function AquariumSection() {
   return (
     <div className="flex w-full flex-col px-20">
       {/* 상단 공용 툴바: 버튼들 y좌표 통일하기 위해 만들었음 === */}
-      <div className="mt-5 mb-3 grid grid-cols-[700px_minmax(420px,1fr)] items-center gap-6">
+      <div className="relative mt-5 mb-3">
         {/* 좌: EXPORT */}
-        <div className="justify-self-end">
+        <div className="flex justify-end" style={{ width: "700px" }}>
           <button
             onClick={() => console.log("EXPORT clicked")}
             className="font-vt ml-4 rounded-full bg-[#3F3F3F]/80 px-8 py-1 text-2xl text-[#D7B9B9] shadow transition-colors hover:bg-[#CA9B9B]/20 focus:ring-2 focus:ring-[#CA9B9B] focus:outline-none"
@@ -82,8 +82,8 @@ export default function AquariumSection() {
           </button>
         </div>
 
-        {/* 우: 탭(Background & Items) + APPLY */}
-        <div className="flex items-center gap-4">
+        {/* 우: 탭(Background & Items) + APPLY - 고정 위치 */}
+        <div className="absolute top-0 right-0 flex items-center gap-4" style={{ width: "500px" }}>
           <div className="flex gap-3">
             <button
               className={`font-vt rounded-md px-6 py-1 text-xl ${
@@ -122,15 +122,15 @@ export default function AquariumSection() {
       </div>
 
       {/* 본문: 캔버스 / 그리드 === */}
-      <div className="grid grid-cols-[700px_minmax(420px,1fr)] items-start gap-6">
+      <div className="relative">
         {/* 좌측: AquariumCanvas */}
-        <div className="justify-self-start">
+        <div style={{ width: "700px" }}>
           <AquariumCanvas width={700} height={440} bgSrc={appliedBgSrc} itemSrc={appliedItemSrc} />
           <p className="font-vt mt-3 text-2xl text-white">Repo contributions: {totalContrib}</p>
         </div>
 
-        {/* 우측: 스크롤 영역만 */}
-        <aside className="w-full max-w-[700px]">
+        {/* 우측: 스크롤 영역만 - 고정 위치 */}
+        <aside className="absolute top-0 right-0 w-[500px]">
           <div
             className="rounded-2xl bg-[linear-gradient(180deg,rgba(255,255,255,0.45)_0%,rgba(255,255,255,0.25)_100%)] p-4 shadow-lg ring-1 ring-white/40 backdrop-blur-md"
             style={{ WebkitBackdropFilter: "blur(6px)" }}

--- a/src/components/MyPage/CanvasControls.tsx
+++ b/src/components/MyPage/CanvasControls.tsx
@@ -16,15 +16,17 @@ export default function CanvasControls({
           className="w-24 rounded border-2 border-[#CA9B9B] bg-transparent px-2 py-1 text-center text-[#D7B9B9] focus:ring-2 focus:ring-[#CA9B9B] focus:outline-none"
           type="number"
           min={200}
+          max={700}
           step={10}
           placeholder="700"
           value={size.width}
-          onChange={(e) =>
+          onChange={(e) => {
+            const newWidth = Number(e.target.value);
             onSizeChange({
               ...size,
-              width: Number(e.target.value),
-            })
-          }
+              width: newWidth > 700 ? 700 : newWidth,
+            });
+          }}
         />
         <span className="font-bold">px</span>
       </label>

--- a/src/components/MyPage/CanvasControls.tsx
+++ b/src/components/MyPage/CanvasControls.tsx
@@ -17,6 +17,7 @@ export default function CanvasControls({
           type="number"
           min={200}
           step={10}
+          placeholder="700"
           value={size.width}
           onChange={(e) =>
             onSizeChange({
@@ -36,6 +37,7 @@ export default function CanvasControls({
           type="number"
           min={150}
           step={10}
+          placeholder="400"
           value={size.height}
           onChange={(e) =>
             onSizeChange({

--- a/src/components/MyPage/FishTankSection.tsx
+++ b/src/components/MyPage/FishTankSection.tsx
@@ -81,6 +81,12 @@ export default function FishTankSection() {
 
   const canvasRef = useRef<HTMLDivElement>(null);
 
+  const handleSizeChange = (newSize: CanvasSize) => {
+    const limitedWidth =
+      typeof newSize.width === "number" && newSize.width > 700 ? 700 : newSize.width;
+    setSize({ ...newSize, width: limitedWidth });
+  };
+
   return (
     <div className="flex w-full flex-col px-20">
       {/* RepoSelect */}
@@ -96,19 +102,24 @@ export default function FishTankSection() {
 
       {/* 상단 공용 툴바: CanvasControls + EXPORT + 탭 + APPLY */}
       <div className="relative mb-4">
-        {/* 좌: CanvasControls + EXPORT */}
+        {/* 좌: CanvasControls */}
         <div
-          className="relative"
-          style={{ width: typeof size.width === "number" ? `${size.width}px` : size.width }}
+          style={{
+            width: typeof size.width === "number" ? `${Math.min(size.width, 700)}px` : size.width,
+            maxWidth: "700px",
+          }}
         >
-          <CanvasControls size={size} onSizeChange={setSize} />
-          <button
-            onClick={() => console.log("EXPORT clicked")}
-            className="font-vt absolute top-0 right-0 rounded-full bg-[#3F3F3F]/80 px-8 py-1 text-2xl text-[#D7B9B9] shadow transition-colors hover:bg-[#CA9B9B]/20 focus:ring-2 focus:ring-[#CA9B9B] focus:outline-none"
-          >
-            EXPORT
-          </button>
+          <CanvasControls size={size} onSizeChange={handleSizeChange} />
         </div>
+
+        {/* EXPORT 버튼 - 고정 위치 */}
+        <button
+          onClick={() => console.log("EXPORT clicked")}
+          className="font-vt absolute top-0 rounded-full bg-[#3F3F3F]/80 px-8 py-1 text-2xl text-[#D7B9B9] shadow transition-colors hover:bg-[#CA9B9B]/20 focus:ring-2 focus:ring-[#CA9B9B] focus:outline-none"
+          style={{ right: "530px" }}
+        >
+          EXPORT
+        </button>
 
         {/* 우: 탭(Background & Items) + APPLY - 고정 위치 */}
         <div className="absolute top-0 right-0 flex items-center gap-4" style={{ width: "500px" }}>
@@ -154,12 +165,14 @@ export default function FishTankSection() {
         {/* 좌측: FishTankCanvas */}
         <div
           style={{
-            width: typeof size.width === "number" ? `${size.width}px` : size.width,
+            width: typeof size.width === "number" ? `${Math.min(size.width, 700)}px` : size.width,
+            maxWidth: "700px",
           }}
         >
           <div
             style={{
-              maxWidth: typeof size.width === "number" ? `${size.width}px` : size.width,
+              maxWidth:
+                typeof size.width === "number" ? `${Math.min(size.width, 700)}px` : size.width,
             }}
           >
             <FishTankCanvas ref={canvasRef} size={size} />

--- a/src/components/MyPage/FishTankSection.tsx
+++ b/src/components/MyPage/FishTankSection.tsx
@@ -13,7 +13,7 @@ type SubTab = "background" | "items";
 
 export default function FishTankSection() {
   const [repo, setRepo] = useState<RepoInfo | null>(null);
-  const [size, setSize] = useState<CanvasSize>({ width: 770, height: 400 });
+  const [size, setSize] = useState<CanvasSize>({ width: 700, height: 400 });
   const [contrib, setContrib] = useState<number>(914);
   // const [timeline] = useState<TimelineItem[]>([
   //   { id: "t1", at: "25/09/14 00:00", fish: { id: "f1", maturity: "Juvenile" } },
@@ -82,7 +82,7 @@ export default function FishTankSection() {
   const canvasRef = useRef<HTMLDivElement>(null);
 
   return (
-    <div className="flex w-full flex-col">
+    <div className="flex w-full flex-col px-20">
       {/* RepoSelect */}
       <div className="font-abeezee mb-10 flex justify-center text-[#B2B2B2]">
         <RepoSelect
@@ -95,7 +95,12 @@ export default function FishTankSection() {
       </div>
 
       {/* 상단 공용 툴바: CanvasControls + EXPORT + 탭 + APPLY */}
-      <div className="mb-4 grid grid-cols-[770px_minmax(420px,1fr)] items-center gap-6">
+      <div
+        className="mb-4 grid items-center gap-6"
+        style={{
+          gridTemplateColumns: `${typeof size.width === "number" ? `${size.width}px` : size.width} minmax(420px, 1fr)`,
+        }}
+      >
         {/* 좌: CanvasControls + EXPORT (고정 위치) */}
         <div className="relative">
           <CanvasControls size={size} onSizeChange={setSize} />
@@ -147,10 +152,19 @@ export default function FishTankSection() {
       </div>
 
       {/* 본문: 캔버스 / 그리드 */}
-      <div className="grid grid-cols-[770px_minmax(420px,1fr)] items-start gap-6">
-        {/* 좌측: FishTankCanvas (최대 너비 770px 제한) */}
+      <div
+        className="grid items-start gap-6"
+        style={{
+          gridTemplateColumns: `${typeof size.width === "number" ? `${size.width}px` : size.width} minmax(420px, 1fr)`,
+        }}
+      >
+        {/* 좌측: FishTankCanvas */}
         <div className="justify-self-start">
-          <div className="max-w-[770px]">
+          <div
+            style={{
+              maxWidth: typeof size.width === "number" ? `${size.width}px` : size.width,
+            }}
+          >
             <FishTankCanvas ref={canvasRef} size={size} />
           </div>
           <p className="font-vt mt-3 text-2xl text-white">Repo contributions: {contrib}</p>

--- a/src/components/MyPage/FishTankSection.tsx
+++ b/src/components/MyPage/FishTankSection.tsx
@@ -95,14 +95,12 @@ export default function FishTankSection() {
       </div>
 
       {/* 상단 공용 툴바: CanvasControls + EXPORT + 탭 + APPLY */}
-      <div
-        className="mb-4 grid items-center gap-6"
-        style={{
-          gridTemplateColumns: `${typeof size.width === "number" ? `${size.width}px` : size.width} minmax(420px, 1fr)`,
-        }}
-      >
-        {/* 좌: CanvasControls + EXPORT (고정 위치) */}
-        <div className="relative">
+      <div className="relative mb-4">
+        {/* 좌: CanvasControls + EXPORT */}
+        <div
+          className="relative"
+          style={{ width: typeof size.width === "number" ? `${size.width}px` : size.width }}
+        >
           <CanvasControls size={size} onSizeChange={setSize} />
           <button
             onClick={() => console.log("EXPORT clicked")}
@@ -112,8 +110,8 @@ export default function FishTankSection() {
           </button>
         </div>
 
-        {/* 우: 탭(Background & Items) + APPLY */}
-        <div className="flex items-center gap-4">
+        {/* 우: 탭(Background & Items) + APPLY - 고정 위치 */}
+        <div className="absolute top-0 right-0 flex items-center gap-4" style={{ width: "500px" }}>
           <div className="flex gap-3">
             <button
               className={`font-vt rounded-md px-6 py-1 text-xl ${
@@ -152,14 +150,13 @@ export default function FishTankSection() {
       </div>
 
       {/* 본문: 캔버스 / 그리드 */}
-      <div
-        className="grid items-start gap-6"
-        style={{
-          gridTemplateColumns: `${typeof size.width === "number" ? `${size.width}px` : size.width} minmax(420px, 1fr)`,
-        }}
-      >
+      <div className="relative">
         {/* 좌측: FishTankCanvas */}
-        <div className="justify-self-start">
+        <div
+          style={{
+            width: typeof size.width === "number" ? `${size.width}px` : size.width,
+          }}
+        >
           <div
             style={{
               maxWidth: typeof size.width === "number" ? `${size.width}px` : size.width,
@@ -170,8 +167,8 @@ export default function FishTankSection() {
           <p className="font-vt mt-3 text-2xl text-white">Repo contributions: {contrib}</p>
         </div>
 
-        {/* 우측: 스크롤 영역만 */}
-        <aside className="w-full max-w-[700px]">
+        {/* 우측: 스크롤 영역만 - 고정 위치 */}
+        <aside className="absolute top-0 right-0 w-[500px]">
           <div
             className="rounded-2xl bg-[linear-gradient(180deg,rgba(255,255,255,0.45)_0%,rgba(255,255,255,0.25)_100%)] p-4 shadow-lg ring-1 ring-white/40 backdrop-blur-md"
             style={{ WebkitBackdropFilter: "blur(6px)" }}

--- a/src/components/MyPage/RepoSelect.tsx
+++ b/src/components/MyPage/RepoSelect.tsx
@@ -17,7 +17,7 @@ export default function RepoSelect({
   return (
     <div className="mt-5 mb-5">
       <select
-        className="font-abeezee w-[1000px] appearance-none rounded-md border border-white/50 bg-[#3E548E] px-3 py-3 pr-10 pl-7 text-white shadow-xl hover:shadow-2xl focus:ring-2 focus:ring-blue-300 focus:outline-none"
+        className="font-abeezee w-[700px] appearance-none rounded-md border border-white/50 bg-[#3E548E] px-3 py-2 pr-10 pl-7 text-white shadow-xl hover:shadow-2xl focus:ring-2 focus:ring-blue-300 focus:outline-none"
         value={value?.id ?? ""}
         onChange={(e) => onChange(REPOS.find((d) => d.id === e.target.value) ?? null)}
       >

--- a/src/components/MyPage/Titles.tsx
+++ b/src/components/MyPage/Titles.tsx
@@ -6,11 +6,11 @@ export default function Titles({
   onChange: (v: "fishtank" | "aquarium") => void;
 }) {
   // 고정 사이즈
-  const BTN_H = "h-17"; // 버튼 높이
-  const BTN_FISHTANK_W = "w-[300px]"; // FISHTANK 폭
-  const BTN_AQUARIUM_W = "w-[300px]"; // AQUARIUM 폭
+  const BTN_H = "h-13"; // 버튼 높이
+  const BTN_FISHTANK_W = "w-[260px]"; // FISHTANK 폭
+  const BTN_AQUARIUM_W = "w-[260px]"; // AQUARIUM 폭
 
-  const base = `rounded-full border-4 ${BTN_H} flex items-center justify-center px-8 transition-colors duration-150`;
+  const base = `rounded-full border-3 ${BTN_H} flex items-center justify-center px-6 transition-colors duration-150`;
   const onBtn = "bg-[#EDF1F8]/80 border-[#CA9B9B]";
   const offBtn = "bg-transparent border-[#CA9B9B]";
 
@@ -25,7 +25,7 @@ export default function Titles({
     <span
       className={`font-bungee leading-none ${className}`}
       style={{
-        WebkitTextStroke: "4px #CA9B9B",
+        WebkitTextStroke: "2px #CA9B9B",
         color: "#FFFFFF",
       }}
     >
@@ -34,9 +34,9 @@ export default function Titles({
   );
 
   return (
-    <div className="flex items-center gap-6">
+    <div className="flex items-center gap-4">
       {/* MY */}
-      <StrokeText className="text-7xl">MY</StrokeText>
+      <StrokeText className="text-5xl">MY</StrokeText>
 
       {/* FISHTANK */}
       <button
@@ -44,9 +44,9 @@ export default function Titles({
         onClick={() => onChange("fishtank")}
       >
         {active === "fishtank" ? (
-          <StrokeText className="text-4xl">FISHTANK</StrokeText>
+          <StrokeText className="text-3xl">FISHTANK</StrokeText>
         ) : (
-          <span className="font-abeezee text-4xl text-[#CA9B9B]">FISHTANK</span>
+          <span className="font-abeezee text-3xl text-[#CA9B9B]">FISHTANK</span>
         )}
       </button>
 
@@ -56,9 +56,9 @@ export default function Titles({
         onClick={() => onChange("aquarium")}
       >
         {active === "aquarium" ? (
-          <StrokeText className="text-4xl">AQUARIUM</StrokeText>
+          <StrokeText className="text-3xl">AQUARIUM</StrokeText>
         ) : (
-          <span className="font-abeezee text-4xl text-[#CA9B9B]">AQUARIUM</span>
+          <span className="font-abeezee text-3xl text-[#CA9B9B]">AQUARIUM</span>
         )}
       </button>
     </div>


### PR DESCRIPTION
# MyPage 레이아웃 및 UI 개선

## 변경 사항

### 레이아웃 조정
- **좌우 여백 추가**: FishTankSection과 AquariumSection에 `px-20` 여백 추가하여 전체적인 레이아웃 여유 공간 확보
- **기본 width 조정**: 
  - AquariumSection: 750px → 700px
  - FishTankSection: 770px → 700px
- **왼쪽 영역 최대 width 제한**: FishTankSection의 캔버스 width 최대값을 700px로 제한하여 레이아웃 안정성 향상

### 오른쪽 컨트롤 패널 고정
- **크기 고정**: 오른쪽 영역을 500px로 고정하여 왼쪽 캔버스 크기 변경과 무관하게 일정한 크기 유지
- **위치 고정**: `absolute` positioning을 사용하여 오른쪽 영역을 화면 오른쪽 끝에 고정 배치
- **EXPORT 버튼 위치 고정**: EXPORT 버튼을 오른쪽 영역 왼쪽에 고정 배치 (간격 30px)

### UI 컴포넌트 크기 조정
- **Titles 컴포넌트**: 
  - "MY" 텍스트: `text-7xl` → `text-5xl`
  - 버튼 높이: `h-17` → `h-13`
  - 버튼 폭: `w-[300px]` → `w-[260px]`
  - 버튼 내부 텍스트: `text-4xl` → `text-3xl`
  - 테두리 및 stroke 두께 감소
- **RepoSelect**: 
  - 너비: `w-[1000px]` → `w-full max-w-[650px]` (Titles 영역과 비슷한 크기)
  - 높이: `py-3` → `py-2`

### CanvasControls 개선
- **Placeholder 추가**: width와 height input에 기본값 placeholder 추가 (700, 400)
- **최대값 제한**: width input에 `max={700}` 속성 추가 및 onChange 핸들러에서 700 초과 시 자동 제한

### AquariumFishTable 개선
- **크기 및 비율 조정**:
  - 전체 너비: `w-[1500px]` → `w-full max-w-[1000px]`
  - 패딩: `p-8` → `p-6`
  - 그리드 컬럼 너비 최적화
  - 행 간격: `space-y-8` → `space-y-4`
  - 토글 버튼 및 썸네일 크기 조정
- **텍스트 크기 증가**:
  - 헤더: `text-xl` → `text-2xl`
  - 본문: `text-lg` → `text-xl`

## 기술적 변경 사항

### FishTankSection
- 그리드 레이아웃에서 absolute positioning으로 전환하여 오른쪽 영역 고정
- `handleSizeChange` 함수 추가로 width 최대값 제한 로직 구현

### AquariumSection
- EXPORT 버튼을 왼쪽 캔버스 영역(700px) 오른쪽 끝에 배치
- 오른쪽 컨트롤 패널을 absolute positioning으로 고정

## 개선 효과
- 레이아웃 안정성 향상: 오른쪽 영역이 고정되어 왼쪽 캔버스 크기 변경 시에도 일관된 UI 유지
- 사용자 경험 개선: 적절한 여백과 크기 조정으로 가독성 및 사용성 향상
- 반응형 개선: 일부 컴포넌트에 max-width 적용으로 다양한 화면 크기 대응

